### PR TITLE
refactor: minor code improvements

### DIFF
--- a/src/is-github-alert-type.test.ts
+++ b/src/is-github-alert-type.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import {isGithubAlertType} from "./is-github-alert-type.js";
+import {GithubAlertType} from "./github-alert.type.js";
+
+describe('is-github-alert-type', () => {
+  it('should return false for an undefined value', () => {
+    expect(isGithubAlertType(undefined)).toEqual(false);
+  });
+
+  it('should return false for a null value', () => {
+    expect(isGithubAlertType(null)).toEqual(false);
+  });
+
+  it('should return false for a string value not equal to a GitHub alert type', () => {
+    expect(isGithubAlertType("test")).toEqual(false);
+  });
+
+  it('should return true for a value directly taken from the GitHub alert type enum', () => {
+    expect(isGithubAlertType(GithubAlertType.WARNING)).toEqual(true);
+  });
+
+  it('should return true for a string value that equals an alert type', () => {
+    expect(isGithubAlertType("IMPORTANT")).toEqual(true);
+  });
+
+  it('should return false for a string value with the wrong capitalization', () => {
+    expect(isGithubAlertType("important")).toEqual(false);
+  });
+})

--- a/src/is-github-alert-type.test.ts
+++ b/src/is-github-alert-type.test.ts
@@ -1,29 +1,29 @@
 import { describe, expect, it } from "vitest";
-import {isGithubAlertType} from "./is-github-alert-type.js";
-import {GithubAlertType} from "./github-alert.type.js";
+import { GithubAlertType } from "./github-alert.type.js";
+import { isGithubAlertType } from "./is-github-alert-type.js";
 
-describe('is-github-alert-type', () => {
-  it('should return false for an undefined value', () => {
+describe("is-github-alert-type", () => {
+  it("should return false for an undefined value", () => {
     expect(isGithubAlertType(undefined)).toEqual(false);
   });
 
-  it('should return false for a null value', () => {
+  it("should return false for a null value", () => {
     expect(isGithubAlertType(null)).toEqual(false);
   });
 
-  it('should return false for a string value not equal to a GitHub alert type', () => {
+  it("should return false for a string value not equal to a GitHub alert type", () => {
     expect(isGithubAlertType("test")).toEqual(false);
   });
 
-  it('should return true for a value directly taken from the GitHub alert type enum', () => {
+  it("should return true for a value directly taken from the GitHub alert type enum", () => {
     expect(isGithubAlertType(GithubAlertType.WARNING)).toEqual(true);
   });
 
-  it('should return true for a string value that equals an alert type', () => {
+  it("should return true for a string value that equals an alert type", () => {
     expect(isGithubAlertType("IMPORTANT")).toEqual(true);
   });
 
-  it('should return false for a string value with the wrong capitalization', () => {
+  it("should return false for a string value with the wrong capitalization", () => {
     expect(isGithubAlertType("important")).toEqual(false);
   });
-})
+});

--- a/src/is-github-alert-type.ts
+++ b/src/is-github-alert-type.ts
@@ -1,0 +1,5 @@
+import {GITHUB_ALERT_TYPES, type GithubAlertType} from "./github-alert.type.js";
+
+export function isGithubAlertType(type: unknown): type is GithubAlertType {
+  return GITHUB_ALERT_TYPES.includes(type as GithubAlertType);
+}

--- a/src/is-github-alert-type.ts
+++ b/src/is-github-alert-type.ts
@@ -1,4 +1,7 @@
-import {GITHUB_ALERT_TYPES, type GithubAlertType} from "./github-alert.type.js";
+import {
+  GITHUB_ALERT_TYPES,
+  type GithubAlertType,
+} from "./github-alert.type.js";
 
 export function isGithubAlertType(type: unknown): type is GithubAlertType {
   return GITHUB_ALERT_TYPES.includes(type as GithubAlertType);

--- a/src/parse-github-alert-blockquote.test.ts
+++ b/src/parse-github-alert-blockquote.test.ts
@@ -4,7 +4,7 @@ import { GithubAlertType } from "./github-alert.type.js";
 import { parseGithubAlertBlockquote } from "./parse-github-alert-blockquote.js";
 
 describe("parse-github-alert-blockquote", () => {
-  it("should return false if the blockquote has no children", () => {
+  it("should return null if the blockquote has no children", () => {
     const blockquote: Blockquote = {
       type: "blockquote",
       children: [],
@@ -12,10 +12,10 @@ describe("parse-github-alert-blockquote", () => {
 
     const result = parseGithubAlertBlockquote(blockquote);
 
-    expect(result).toBe(false);
+    expect(result).toBe(null);
   });
 
-  it("should return false if the first chlid of the blockquote is not a paragraph", () => {
+  it("should return null if the first child of the blockquote is not a paragraph", () => {
     const blockquote: Blockquote = {
       type: "blockquote",
       children: [
@@ -34,10 +34,10 @@ describe("parse-github-alert-blockquote", () => {
 
     const result = parseGithubAlertBlockquote(blockquote);
 
-    expect(result).toBe(false);
+    expect(result).toBe(null);
   });
 
-  it("should return false if the first child of the paragraph is not a text node", () => {
+  it("should return null if the first child of the paragraph is not a text node", () => {
     const blockquote: Blockquote = {
       type: "blockquote",
       children: [
@@ -60,10 +60,10 @@ describe("parse-github-alert-blockquote", () => {
 
     const result = parseGithubAlertBlockquote(blockquote);
 
-    expect(result).toBe(false);
+    expect(result).toBe(null);
   });
 
-  it("should return false if the first paragraph child doesn't contain a valid alert declaration", () => {
+  it("should return null if the first paragraph child doesn't contain a valid alert declaration", () => {
     const blockquote: Blockquote = {
       type: "blockquote",
       children: [
@@ -81,7 +81,7 @@ describe("parse-github-alert-blockquote", () => {
 
     const result = parseGithubAlertBlockquote(blockquote);
 
-    expect(result).toBe(false);
+    expect(result).toBe(null);
   });
 
   it("should return the parsed alert if the blockquote is a valid alert", () => {

--- a/src/parse-github-alert-blockquote.ts
+++ b/src/parse-github-alert-blockquote.ts
@@ -1,6 +1,6 @@
 import type { Blockquote, Paragraph, Text } from "mdast";
 import type { GithubAlert } from "./github-alert.type.js";
-import { parseGithubAlertDeclaration } from "./is-github-alert-declaration.js";
+import { parseGithubAlertDeclaration } from "./parse-github-alert-declaration.js";
 
 /**
  * Function that checks if a given blockquote is a GitHub alert and returns the
@@ -8,25 +8,23 @@ import { parseGithubAlertDeclaration } from "./is-github-alert-declaration.js";
  */
 export function parseGithubAlertBlockquote(
   node: Blockquote,
-): false | GithubAlert {
+): GithubAlert | null {
   const [firstChild, ...blockQuoteChildren] = node.children;
 
-  if (firstChild === undefined) return false;
-  if (firstChild.type !== "paragraph") return false;
+  if (firstChild?.type !== "paragraph") return null;
 
   const [firstParagraphChild, ...paragraphChildren] = firstChild.children;
 
-  if (firstParagraphChild === undefined) return false;
-  if (firstParagraphChild.type !== "text") return false;
+  if (firstParagraphChild?.type !== "text") return null;
 
   const [possibleTypeDeclaration, ...textNodes] =
     firstParagraphChild.value.split("\n");
 
-  if (possibleTypeDeclaration === undefined) return false;
+  if (possibleTypeDeclaration === undefined) return null;
 
   const type = parseGithubAlertDeclaration(possibleTypeDeclaration);
 
-  if (type === false) return false;
+  if (type === null) return null;
 
   const textNodeChildren: Text[] =
     textNodes.length > 0 ? [{ type: "text", value: textNodes.join("\n") }] : [];

--- a/src/parse-github-alert-declaration.test.ts
+++ b/src/parse-github-alert-declaration.test.ts
@@ -1,19 +1,19 @@
 import { describe, expect, it } from "vitest";
 import { GithubAlertType } from "./github-alert.type.js";
-import { parseGithubAlertDeclaration } from "./is-github-alert-declaration.js";
+import { parseGithubAlertDeclaration } from "./parse-github-alert-declaration.js";
 
-describe("is-github-alert-declaration", () => {
-  it("should return false when passing an empty string.", () => {
+describe("parse-github-alert-declaration", () => {
+  it("should return null when passing an empty string.", () => {
     const result = parseGithubAlertDeclaration("");
-    expect(result).toBe(false);
+    expect(result).toBe(null);
   });
 
-  it("should return false when passing a string that's not a Github alert declaration.", () => {
+  it("should return null when passing a string that is not a Github alert declaration.", () => {
     const resultOne = parseGithubAlertDeclaration("test");
-    expect(resultOne).toBe(false);
+    expect(resultOne).toBe(null);
 
     const resultTwo = parseGithubAlertDeclaration("[!TEST]");
-    expect(resultTwo).toBe(false);
+    expect(resultTwo).toBe(null);
   });
 
   it("should return the alert type when passing a string that is a Github alert declaration.", () => {

--- a/src/parse-github-alert-declaration.ts
+++ b/src/parse-github-alert-declaration.ts
@@ -1,12 +1,12 @@
 import {
-  GITHUB_ALERT_TYPES,
   type GithubAlertType,
 } from "./github-alert.type.js";
+import { isGithubAlertType } from "./is-github-alert-type.js";
 
 const GITHUB_ALERT_DECLARATION_REGEX = /^\s*\[\!(?<type>\w+)\]\s*$/;
 
 /**
- * Function that checks if a given string is a Github alert declaration and
+ * Function that checks if a given string is a GitHub alert declaration and
  * returns the parsed alert type if it is.
  *
  * A GitHub alert declaration is a string that is structured like this:
@@ -15,15 +15,10 @@ const GITHUB_ALERT_DECLARATION_REGEX = /^\s*\[\!(?<type>\w+)\]\s*$/;
  */
 export function parseGithubAlertDeclaration(
   text: string,
-): false | GithubAlertType {
+): GithubAlertType | null {
   const match = text.match(GITHUB_ALERT_DECLARATION_REGEX);
 
-  if (match === null) return false;
+  const type = match?.groups?.type;
 
-  const type = match.groups?.type;
-
-  if (type === undefined) return false;
-  if (!GITHUB_ALERT_TYPES.includes(type as GithubAlertType)) return false;
-
-  return type as GithubAlertType;
+  return isGithubAlertType(type) ? type : null;
 }

--- a/src/parse-github-alert-declaration.ts
+++ b/src/parse-github-alert-declaration.ts
@@ -1,6 +1,4 @@
-import {
-  type GithubAlertType,
-} from "./github-alert.type.js";
+import { type GithubAlertType } from "./github-alert.type.js";
 import { isGithubAlertType } from "./is-github-alert-type.js";
 
 const GITHUB_ALERT_DECLARATION_REGEX = /^\s*\[\!(?<type>\w+)\]\s*$/;

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -13,7 +13,7 @@ export const remarkGithubAdmonitionsToDirectives: Plugin<[], Root> = () => {
       (node: Blockquote, index?: number, parent?: Parent) => {
         const githubAlert = parseGithubAlertBlockquote(node);
 
-        if (githubAlert === false) return;
+        if (githubAlert === null) return;
 
         const directive: ContainerDirective = {
           type: "containerDirective",


### PR DESCRIPTION
Thanks for this plugin, @LuudJanssen. In this PR, I have made some minor code adjustments to improve readability and increase the semantic value of the code. These changes can roughly be split into three different subjects, which I will outline, below:

## Swap returning `false` for returning `null` when no result can be returned
Some functions return either a result or `false` when no result can be provided. I do not think this is semantically correct, as I expect `false` to be returned only when in a type guard or another assertion function. When a function parses and returns data, I expect either an error to be raised or `null` to be returned as a value to signal the parsing was completed successfully, but no valid result could be retrieved from parsing, therefore returning `null`.

## Change `is-github-alert-declaration.ts` to `parse-github-alert-declaration.ts`
The function contained in this file was called `parseGithubAlertDeclaration`. I believe file names should follow function naming and have changed this in this PR.

## Add type guard function to check whether provided type is a GitHub alert type
Before this PR, we needed to typecast the `type` variable in `parseGithubAlertDeclaration` twice. Once to check whether the type was correct and twice when returning. I have added a utility to check whether a type is a GitHub alert type, which borrows its logic directly from the previous code. The second advantage of stripping this logic into a separate function is that we can test that function directly and ensuring that, during parsing, only the correct types are being parsed - without having to test the flow of multiple functions.