### PR TITLE
fix!: map GitHub 'IMPORTANT' admonition to docusaurus 'info' admonition (fixes #6)

### DIFF
--- a/src/map-github-alert-type-to-directive-name.ts
+++ b/src/map-github-alert-type-to-directive-name.ts
@@ -14,7 +14,7 @@ export function mapGithubAlertTypeToDirectiveName(
       return "warning";
 
     case GithubAlertType.IMPORTANT:
-      return "warning";
+      return "info";
 
     case GithubAlertType.CAUTION:
       return "danger";

--- a/src/plugin.test.ts
+++ b/src/plugin.test.ts
@@ -32,6 +32,46 @@ describe("remark-github-admonitions-to-directives", () => {
     `);
   });
 
+  it("should convert a tip admonition to a tip directive", async () => {
+    const result = await process(`> [!TIP]`);
+
+    expect(result).toMatchInlineSnapshot(`
+      ":::tip
+      :::
+      "
+    `);
+  });
+
+  it("should convert a important admonition to an info directive", async () => {
+    const result = await process(`> [!IMPORTANT]`);
+
+    expect(result).toMatchInlineSnapshot(`
+      ":::info
+      :::
+      "
+    `);
+  });
+
+  it("should convert a warning admonition to a warning directive", async () => {
+    const result = await process(`> [!WARNING]`);
+
+    expect(result).toMatchInlineSnapshot(`
+      ":::warning
+      :::
+      "
+    `);
+  });
+
+  it("should convert a caution admonition to a danger directive", async () => {
+    const result = await process(`> [!CAUTION]`);
+
+    expect(result).toMatchInlineSnapshot(`
+      ":::danger
+      :::
+      "
+    `);
+  });
+
   it("should handle nested content", async () => {
     const result = await process(`> [!NOTE]
 > test


### PR DESCRIPTION
Fixes #6 